### PR TITLE
Closes #1 Add centrifugo API core functions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# Specify your gem's dependencies in centrifuge.gemspec
+# Specify your gem's dependencies in rubycent.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rubycent
 
+[![Build Status](https://travis-ci.com/Warshavski/rubycent.svg?branch=master)](https://travis-ci.com/Warshavski/rubycent)
+
 Ruby tools to communicate with [Centrifugo v2 HTTP API.](https://centrifugal.github.io/centrifugo/server/http_api/)
 
 ## Installation
@@ -30,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/centrifuge. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/warshavski/rubycent. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -38,4 +40,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Centrifuge project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/centrifuge/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Rubycent project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/rubycent/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/rubycent.rb
+++ b/lib/rubycent.rb
@@ -1,8 +1,51 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+require 'multi_json'
+
 require 'rubycent/version'
 
+require 'rubycent/client'
+require 'rubycent/request'
+
+require 'rubycent/error'
+require 'rubycent/errors/network_error'
+require 'rubycent/errors/request_error'
+require 'rubycent/errors/response_error'
+
+# Rubycent
+#
+#   Entry point and configuration definition
+#
 module Rubycent
-  class Error < StandardError; end
-  # Your code goes here...
+  class << self
+    extend Forwardable
+
+    def_delegators :api_client, :scheme, :host, :port, :secret, :api_key
+    def_delegators :api_client, :scheme=, :host=, :port=, :secret=, :api_key=
+
+    def_delegators :api_client, :timeout=, :open_timeout=
+
+    def_delegators :api_client,
+                   :publish, :broadcast,
+                   :unsubscribe, :disconnect,
+                   :presence, :presence_stats,
+                   :history, :channels, :info
+
+    attr_writer :logger, :request_adapter
+
+    def logger
+      @logger ||= begin
+        Logger.new($stdout).tap { |log| log.level = Logger::INFO }
+      end
+    end
+
+    def request_adapter
+      @request_adapter ||= Faraday.default_adapter
+    end
+
+    def api_client
+      @api_client ||= Rubycent::Client.new
+    end
+  end
 end

--- a/lib/rubycent/client.rb
+++ b/lib/rubycent/client.rb
@@ -1,0 +1,342 @@
+# frozen_string_literal: true
+
+require 'rubycent/query'
+
+module Rubycent
+  # Rubycent::Client
+  #
+  #   Main object that handles configuration and requests to centrifugo API
+  #
+  class Client
+    DEFAULT_OPTIONS = {
+      scheme: 'http',
+      host: 'localhost',
+      port: 8000
+    }.freeze
+
+    private_constant :DEFAULT_OPTIONS
+
+    attr_accessor :scheme, :host, :port, :secret, :api_key
+
+    attr_accessor :timeout, :open_timeout
+
+    # @param options [Hash] -
+    #   (default: {}) Parameters to configure centrifugo client
+    #
+    # @option options [String] :scheme -
+    #   Centrifugo address scheme
+    #
+    # @option options [String] :host -
+    #   Centrifugo address host
+    #
+    # @option options [String] :port -
+    #   Centrifugo address port
+    #
+    # @option options [String] :secret -
+    #   Centrifugo secret(used to issue JWT)
+    #
+    # @option options [String] :api_key -
+    #   Centrifugo API key(used to perform requests)
+    #
+    # @option options [String] :timeout -
+    #   Number of seconds to wait for the connection to open.
+    #
+    # @option options [String] :open_timeout -
+    #   Number of seconds to wait for one block to be read.
+    #
+    # @example Construct new client instance
+    #   Rubycent::Client.new(
+    #     scheme: 'http',
+    #     host: 'localhost',
+    #     port: '8000',
+    #     secret: 'secret',
+    #     api_key: 'api key',
+    #     timeout: 10,
+    #     open_timeout: 15
+    #   )
+    #
+    def initialize(options = {})
+      options = DEFAULT_OPTIONS.merge(options)
+
+      @scheme, @host, @port, @secret, @api_key = options.values_at(
+        :scheme, :host, :port, :secret, :api_key
+      )
+
+      @timeout = 5
+      @open_timeout = 5
+    end
+
+    # Publish data into channel
+    #
+    # @param channel [String] -
+    #   Name of the channel to publish
+    #
+    # @param data [Hash] -
+    #   Data for publication in the channel
+    #
+    # @example Publish `content: 'hello'` into `chat` channel
+    #   Rubycent::Client.new.publish('chat', content: 'hello') #=> {}
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#publish)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] - Return empty hash in case of successful publish
+    #
+    def publish(channel, data)
+      construct_query.execute('publish', channel: channel, data: data)
+    end
+
+    # Publish data into multiple channels
+    #   (Similar to `#publish` but allows to send the same data into many channels)
+    #
+    # @param channels [Array<String>] - Collection of channels names to publish
+    # @param data [Hash] - Data for publication in the channels
+    #
+    # @example Broadcast `content: 'hello'` into `channel_1`, 'channel_2' channels
+    #   Rubycent::Client.new.broadcast(['channel_1', 'channel_2'], content: 'hello') #=> {}
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#broadcast)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] - Return empty hash in case of successful broadcast
+    #
+    def broadcast(channels, data)
+      construct_query.execute('broadcast', channels: channels, data: data)
+    end
+
+    # Unsubscribe user from channel
+    #
+    # @param channel [String] -
+    #   Channel name to unsubscribe from
+    #
+    # @param user_id [String, Integer] -
+    #   User ID you want to unsubscribe
+    #
+    # @example Unsubscribe user with `id = 1` from `chat` channel
+    #   Rubycent::Client.new.unsubscribe('chat', 1) #=> {}
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#unsubscribe)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] - Return empty hash in case of successful unsubscribe
+    #
+    def unsubscribe(channel, user_id)
+      construct_query.execute('unsubscribe', channel: channel, user: user_id)
+    end
+
+    # Disconnect user by it's ID
+    #
+    # @param user_id [String, Integer] -
+    #   User ID you want to disconnect
+    #
+    # @example Disconnect user with `id = 1`
+    #   Rubycent::Client.new.disconnect(1) #=> {}
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#disconnect)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] - Return empty hash in case of successful disconnect
+    #
+    def disconnect(user_id)
+      construct_query.execute('disconnect', user: user_id)
+    end
+
+    # Get channel presence information
+    #   (all clients currently subscribed on this channel)
+    #
+    # @param channel [String] - Name of the channel
+    #
+    # @example Get presence information for channel `chat`
+    #   Rubycent::Client.new.presence('chat') #=> {
+    #     "result" => {
+    #       "presence" => {
+    #         "c54313b2-0442-499a-a70c-051f8588020f" => {
+    #           "client" => "c54313b2-0442-499a-a70c-051f8588020f",
+    #           "user" => "42"
+    #         },
+    #         "adad13b1-0442-499a-a70c-051f858802da" => {
+    #           "client" => "adad13b1-0442-499a-a70c-051f858802da",
+    #           "user" => "42"
+    #         }
+    #       }
+    #     }
+    #   }
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#presence)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] -
+    #   Return hash with information about all clients currently subscribed on this channel
+    #
+    def presence(channel)
+      construct_query.execute('presence', channel: channel)
+    end
+
+    # Get short channel presence information
+    #
+    # @param channel [String] - Name of the channel
+    #
+    # @example Get short presence information for channel `chat`
+    #   Rubycent::Client.new.presence_stats('chat') #=> {
+    #     "result" => {
+    #       "num_clients" => 0,
+    #       "num_users" => 0
+    #     }
+    #   }
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#presence_stats)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] -
+    #   Return hash with short presence information about channel
+    #
+    def presence_stats(channel)
+      construct_query.execute('presence_stats', channel: channel)
+    end
+
+    # Get channel history information
+    #   (list of last messages published into channel)
+    #
+    # @param channel [String] - Name of the channel
+    #
+    # @example Get history for channel `chat`
+    #   Rubycent::Client.new.history('chat') #=> {
+    #     "result" => {
+    #       "publications" => [
+    #         {
+    #           "data" => {
+    #             "text" => "hello"
+    #           },
+    #           "uid" => "BWcn14OTBrqUhTXyjNg0fg"
+    #         },
+    #         {
+    #           "data" => {
+    #             "text" => "hi!"
+    #           },
+    #           "uid" => "Ascn14OTBrq14OXyjNg0hg"
+    #         }
+    #       ]
+    #     }
+    #   }
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#history)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] -
+    #   Return hash with a list of last messages published into channel
+    #
+    def history(channel)
+      construct_query.execute('history', channel: channel)
+    end
+
+    # Get list of active(with one or more subscribers) channels.
+    #
+    # @example Get active channels list
+    #   Rubycent::Client.new.channels #=> {
+    #     "result" => {
+    #       "channels" => [
+    #         "chat"
+    #       ]
+    #     }
+    #   }
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#channels)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] -
+    #   Return hash with a list of active channels
+    #
+    def channels
+      construct_query.execute('channels', {})
+    end
+
+    # Get information about running Centrifugo nodes
+    #
+    # @example Get running centrifugo nodes list
+    #   Rubycent::Client.new.info #=> {
+    #     "result" => {
+    #       "nodes" => [
+    #         {
+    #           "name" => "Alexanders-MacBook-Pro.local_8000",
+    #           "num_channels" => 0,
+    #           "num_clients" => 0,
+    #           "num_users" => 0,
+    #           "uid" => "f844a2ed-5edf-4815-b83c-271974003db9",
+    #           "uptime" => 0,
+    #           "version" => ""
+    #         }
+    #       ]
+    #     }
+    #   }
+    #
+    # @see (https://centrifugal.github.io/centrifugo/server/http_api/#info)
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] -
+    #   Return hash with a list of last messages published into channel
+    #
+    def info
+      construct_query.execute('info', {})
+    end
+
+    private
+
+    def construct_query
+      Query.new(self)
+    end
+  end
+end

--- a/lib/rubycent/error.rb
+++ b/lib/rubycent/error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Rubycent
+  # Rubycent::Error
+  #
+  #   Wrapper for all rubycent errors(failures).
+  #
+  class Error < StandardError; end
+end

--- a/lib/rubycent/errors/network_error.rb
+++ b/lib/rubycent/errors/network_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Rubycent
+  # Rubycent::NetworkError
+  #
+  #   Raised when request to Centrifugo API failed due the network problems.
+  #
+  class NetworkError < Error
+    attr_accessor :original_error
+  end
+end

--- a/lib/rubycent/errors/request_error.rb
+++ b/lib/rubycent/errors/request_error.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Rubycent
+  # Rubycent::RequestError
+  #
+  #   Raised when request to Centrifugo API failed in some way.
+  #
+  class RequestError < Error
+    attr_reader :message, :status
+
+    def initialize(message, status)
+      @message = message
+      @status = status
+
+      super(message)
+    end
+  end
+end

--- a/lib/rubycent/errors/response_error.rb
+++ b/lib/rubycent/errors/response_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Rubycent
+  # Rubycent::ResponseError
+  #
+  #   Raised when response from Centrifugo contains any error as result of API command execution.
+  #
+  class ResponseError < Error
+    attr_reader :message, :code
+
+    def initialize(error_data)
+      @message, @code = error_data.values_at('message', 'code')
+
+      super(@message)
+    end
+  end
+end

--- a/lib/rubycent/query.rb
+++ b/lib/rubycent/query.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+require 'rubycent/request'
+
+module Rubycent
+  # Rubycent::Query
+  #
+  #   Centrifugo API request configuration and execution
+  #
+  class Query
+    attr_reader :client
+
+    # @param client [Rubycent::Client] -
+    #   Rubycent client that contains all the configuration
+    #
+    def initialize(client)
+      @client = client
+    end
+
+    # Perform centrifugo API call
+    #
+    # @param method [String] -
+    #   Centrifugo command, represents centrifugo actions such as 'publish', 'broadcast', e.t.c.
+    #
+    # @param data [Hash] -
+    #   Any data that will be sent as command parameters
+    #
+    # @return [Hash] - Parser request responce
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    def execute(method, data)
+      body = dump_body(method, data)
+
+      params = {
+        timeout: client.timeout,
+        open_timeout: client.open_timeout
+      }
+
+      headers = build_headers(client.api_key)
+      endpoint = build_endpoint(client.host, client.port, client.scheme.to_s)
+
+      Rubycent::Request.new(endpoint, params, body, headers).post
+    end
+
+    private
+
+    def dump_body(method, params)
+      MultiJson.dump(method: method, params: params)
+    end
+
+    def build_endpoint(host, port, scheme)
+      ::URI::Generic.build(scheme: scheme, host: host, port: port, path: '/api').to_s
+    end
+
+    def build_headers(api_key)
+      {
+        'Content-Type' => 'application/json',
+        'Authorization' => "apikey #{api_key}"
+      }
+    end
+  end
+end

--- a/lib/rubycent/request.rb
+++ b/lib/rubycent/request.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module Rubycent
+  # Rubycent::Request
+  #
+  #   Holds request call and response handling logic
+  #
+  class Request
+    attr_accessor :endpoint, :params, :body, :headers
+
+    # @param endpoint [String] - Centrifugo API endpoint
+    #
+    # @param params [Hash] - Additional params to configure request.
+    #
+    # @option params [Integer] :timeout -
+    #   Number of seconds to wait for the connection to open.
+    #
+    # @option params [Integer] :open_timeout -
+    #   Number of seconds to wait for one block to be read.
+    #
+    # @param body [String] -
+    #   (default: nil) JSON string representing request parameters.
+    #
+    # @param headers [Hash] -
+    #   (default: {}) Additional HTTP headers(such as Content-Type and Authorization).
+    #
+    def initialize(endpoint, params, body = nil, headers = {})
+      @endpoint = endpoint
+      @params = params
+      @body = body
+      @headers = headers
+    end
+
+    # Perform POST request to centrifugo API
+    #
+    # @raise [
+    #   Rubycent::Error,
+    #   Rubycent::NetworkError,
+    #   Rubycent::RequestError,
+    #   Rubycent::ResponseError
+    # ]
+    #
+    # @return [Hash] - Parsed response body
+    #
+    def post
+      response = rest_client.post(@endpoint) do |request|
+        configure_request(request: request, body: body, headers: headers)
+      end
+
+      handle_response(response)
+    rescue Faraday::ConnectionFailed => e
+      handle_error(e)
+    end
+
+    private
+
+    def rest_client
+      Faraday.new do |faraday|
+        faraday.adapter(Rubycent.request_adapter)
+        faraday.headers = @headers
+      end
+    end
+
+    def configure_request(request: nil, headers: nil, body: nil)
+      return if request.nil?
+
+      request.headers.merge!(headers) if headers
+      request.body = body if body
+
+      request.options.timeout = @params[:timeout]
+      request.options.open_timeout = @params[:open_timeout]
+    end
+
+    def handle_response(response)
+      response.status == 200 ? parse_response(response) : raise_error(response)
+    end
+
+    def parse_response(response)
+      MultiJson.load(response.body).tap do |data|
+        raise ResponseError, data['error'] if data.key?('error')
+      end
+    end
+
+    def raise_error(response)
+      status_code = response.status
+      body = response.body
+
+      message = resolve_error_message(status_code, body)
+
+      case status_code
+      when 400..404
+        raise RequestError.new(message, status_code)
+      else
+        raise Error, message
+      end
+    end
+
+    def resolve_error_message(status, additional_info = nil)
+      error_messages = {
+        400 => "Bad request: #{additional_info}",
+        401 => 'Invalid API key',
+        404 => 'Route not found'
+      }
+
+      error_messages.fetch(status) do
+        "Status: #{status}. Unknown error: #{additional_info}"
+      end
+    end
+
+    def handle_error(error)
+      message = "#{error.message} (#{error.class})"
+
+      wrapper = NetworkError.new(message).tap do |w|
+        w.original_error = error
+      end
+
+      raise wrapper
+    end
+  end
+end

--- a/rubycent.gemspec
+++ b/rubycent.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Warshavski']
   spec.email         = ['p.warshavski@gmail.com']
 
-  spec.summary       = 'Ruby client to communicate with Centrifugo'
-  spec.description   = 'Ruby client to communicate with Centrifugo'
+  spec.summary       = 'Ruby client to communicate with Centrifugo v2 HTTP API'
+  spec.description   = 'Ruby client to communicate with Centrifugo v2 HTTP API'
   spec.homepage      = 'https://github.com/Warshavski/rubycent'
   spec.license       = 'MIT'
 
@@ -34,7 +34,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'multi_json'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/rubycent/client_spec.rb
+++ b/spec/rubycent/client_spec.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rubycent::Client do
+  let!(:channel) { 'chat' }
+
+  let!(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Authorization' => 'apikey api_key'
+    }
+  end
+
+  let!(:client) { described_class.new(api_key: 'api_key') }
+
+  before do
+    stub_request(:post, 'http://localhost:8000/api')
+      .with(body: params, headers: headers)
+      .to_return(status: 200, body: expected_body)
+  end
+
+  context 'empty body responses' do
+    let!(:expected_body) { '{}' }
+
+    describe '#publish' do
+      let(:data) { { content: 'wat' } }
+
+      let(:params) do
+        {
+          method: 'publish',
+          params: { channel: channel, data: data }
+        }
+      end
+
+      subject { client.publish(channel, data) }
+
+      it { is_expected.to eq({}) }
+    end
+
+    describe '#broadcast' do
+      let(:data) { { content: 'wat' } }
+
+      let(:params) do
+        {
+          method: 'broadcast',
+          params: { channels: [channel], data: data }
+        }
+      end
+
+      subject { client.broadcast([channel], data) }
+
+      it { is_expected.to eq({}) }
+    end
+
+    describe '#unsubscribe' do
+      let(:params) do
+        {
+          method: 'unsubscribe',
+          params: { channel: channel, user: 1 }
+        }
+      end
+
+      subject { client.unsubscribe(channel, 1) }
+
+      it { is_expected.to eq({}) }
+    end
+
+    describe '#disconnect' do
+      let(:params) do
+        {
+          method: 'disconnect',
+          params: { user: 1 }
+        }
+      end
+
+      subject { client.disconnect(1) }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+
+  context 'presence' do
+    let!(:expected_body) do
+      '{
+        "result": {
+          "presence": {
+            "c54313b2-0442-499a-a70c-051f8588020f": {
+              "client": "c54313b2-0442-499a-a70c-051f8588020f",
+              "user": "42"
+            }
+          }
+        }
+      }'
+    end
+
+    describe '#presence' do
+      let(:params) do
+        {
+          method: 'presence',
+          params: { channel: channel }
+        }
+      end
+
+      subject { client.presence(channel) }
+
+      it 'returns hash with channel presence information' do
+        expected_hash = {
+          'result' => {
+            'presence' => {
+              'c54313b2-0442-499a-a70c-051f8588020f' => {
+                'client' => 'c54313b2-0442-499a-a70c-051f8588020f',
+                'user' => '42'
+              }
+            }
+          }
+        }
+
+        is_expected.to eq(expected_hash)
+      end
+    end
+  end
+
+  context 'presence_stats' do
+    let!(:expected_body) do
+      '{
+        "result": {
+          "num_clients": 0,
+          "num_users": 0
+        }
+      }'
+    end
+
+    describe '#presence_stats' do
+      let(:params) do
+        {
+          method: 'presence_stats',
+          params: { channel: channel }
+        }
+      end
+
+      subject { client.presence_stats(channel) }
+
+      it 'returns hash with channel presence_stats information' do
+        expected_hash = {
+          'result' => {
+            'num_clients' => 0,
+            'num_users' => 0
+          }
+        }
+
+        is_expected.to eq(expected_hash)
+      end
+    end
+  end
+
+  context 'history' do
+    let!(:expected_body) do
+      '{
+        "result": {
+          "publications": [
+            {
+              "data": {
+                "text": "hello"
+              },
+              "uid": "BWcn14OTBrqUhTXyjNg0fg"
+            }
+          ]
+        }
+      }'
+    end
+
+    describe '#history' do
+      let(:params) do
+        {
+          method: 'history',
+          params: { channel: channel }
+        }
+      end
+
+      subject { client.history(channel) }
+
+      it 'returns channel history information' do
+        expected_hash = {
+          'result' => {
+            'publications' => [
+              {
+                'data' => {
+                  'text' => 'hello'
+                },
+                'uid' => 'BWcn14OTBrqUhTXyjNg0fg'
+              }
+            ]
+          }
+        }
+
+        is_expected.to eq(expected_hash)
+      end
+    end
+  end
+
+  context 'channels' do
+    let!(:expected_body) do
+      '{
+          "result": {
+            "channels": [
+              "chat"
+            ]
+          }
+       }'
+    end
+
+    describe '#channels' do
+      let(:params) do
+        {
+          method: 'channels',
+          params: {}
+        }
+      end
+
+      subject { client.channels }
+
+      it 'returns channel history information' do
+        expected_hash = {
+          'result' => {
+            'channels' => [
+              'chat'
+            ]
+          }
+        }
+
+        is_expected.to eq(expected_hash)
+      end
+    end
+  end
+
+  context 'info' do
+    let!(:expected_body) do
+      '{
+        "result": {
+          "nodes": [
+            {
+              "name": "Alexanders-MacBook-Pro.local_8000",
+              "num_channels": 0,
+              "num_clients": 0,
+              "num_users": 0,
+              "uid": "f844a2ed-5edf-4815-b83c-271974003db9",
+              "uptime": 0,
+              "version": ""
+            }
+          ]
+        }
+      }'
+    end
+
+    describe '#info' do
+      let(:params) do
+        {
+          method: 'info',
+          params: {}
+        }
+      end
+
+      subject { client.info }
+
+      it 'returns channel history information' do
+        expected_hash = {
+          'result' => {
+            'nodes' => [
+              {
+                'name' => 'Alexanders-MacBook-Pro.local_8000',
+                'num_channels' => 0,
+                'num_clients' => 0,
+                'num_users' => 0,
+                'uid' => 'f844a2ed-5edf-4815-b83c-271974003db9',
+                'uptime' => 0,
+                'version' => ''
+              }
+            ]
+          }
+        }
+
+        is_expected.to eq(expected_hash)
+      end
+    end
+  end
+end

--- a/spec/rubycent/query_spec.rb
+++ b/spec/rubycent/query_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rubycent::Query do
+  let!(:client) do
+    double('client', api_key: 'KEY', host: 'wathost', port: 3011, scheme: 'https', timeout: 1, open_timeout: 1)
+  end
+
+  let!(:request_params) do
+    {
+      headers: {
+        'Content-Type' => 'application/json',
+        'Authorization' => "apikey KEY"
+      },
+      body: {
+        method: 'watever',
+        params: {
+          content: 'wat'
+        }
+      }
+    }
+  end
+
+  before do
+    stub_request(:post, 'https://wathost:3011/api').with(request_params).to_return(body: '{}')
+  end
+
+  subject { described_class.new(client).execute('watever', content: 'wat') }
+
+  it { is_expected.to eq({}) }
+end

--- a/spec/rubycent/request_spec.rb
+++ b/spec/rubycent/request_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rubycent::Request do
+  let!(:endpoint) { 'http://localhost:3000/api' }
+
+  let!(:params) { { timeout: 5, open_timeout: 5 } }
+  let!(:body)   { { method: 'watever', params: { content: 'wat' } } }
+
+  describe '#post' do
+    subject { described_class.new(endpoint, params, body).post }
+
+    it 'surfaces Faraday::ConnectionFailed exception as a Rubycent::NetworkError' do
+      exception = Faraday::ConnectionFailed.new('not good at all')
+
+      stub_request(:post, endpoint).to_raise(exception)
+
+      expect { subject }.to raise_error(Rubycent::NetworkError)
+    end
+
+    it 'surfaces response with status 400 as a Rubycent::RequestError' do
+      response_values = { status: 400, headers: {}, body: 'smt. goes wrong' }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      expect { subject }.to raise_error(Rubycent::RequestError)
+    end
+
+    it 'surfaces response with status 401 as a Rubycent::RequestError' do
+      response_values = { status: 401, headers: {}, body: 'authorization failed' }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      expect { subject }.to raise_error(Rubycent::RequestError)
+    end
+
+    it 'surfaces response with status 404 as a Rubycent::RequestError' do
+      response_values = { status: 401, headers: {}, body: 'resource not found' }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      expect { subject }.to raise_error(Rubycent::RequestError)
+    end
+
+    it 'surfaces response with status 500 as a Rubycent::Error' do
+      response_values = { status: 500, headers: {}, body: 'unknown error' }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      expect { subject }.to raise_error(Rubycent::Error)
+    end
+
+    it 'surfaces response with status 200 and error section as a Rubycent::ResponseError' do
+      response_values = {
+        status: 200,
+        headers: {},
+        body: {
+          error: {
+            message: 'not valid',
+            code: 102
+          }
+        }.to_json
+      }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      expect { subject }.to raise_error(Rubycent::ResponseError)
+    end
+
+    it 'returns request body as hash in case of the valid request' do
+      response_values = { status: 200, headers: {}, body: {}.to_json }
+
+      stub_request(:post, endpoint).to_return(response_values)
+
+      is_expected.to eq({})
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,11 @@
 require 'bundler/setup'
 require 'rubycent'
 
+require 'webmock/rspec'
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
Added core functions that allow interacting with Centrifugo API

- `publish` - allows to publish data into the channel.
- `broadcast` - similar to `publish` but allows to send the same data into many channels.
- `unsubscribe` - allows to unsubscribe user from channel.
- `disconnect` - allows to disconnect user by ID.
- `presence` - allows to get channel presence information (all clients currently subscribed on this channel).
- `presence_stats` - allows to get short channel presence information.
- `history` - allows to get channel history information (list of last messages published into channel).
- `channels` - allows to get list of active (with one or more subscribers) channels.
- `info` - allows to get information about running Centrifugo nodes.

For detailed info see: https://centrifugal.github.io/centrifugo/server/http_api/